### PR TITLE
Fix reprojection bug

### DIFF
--- a/frank/geometry.py
+++ b/frank/geometry.py
@@ -104,15 +104,15 @@ def deproject(u, v, inc, PA, inverse=False):
     sin_t = np.sin(PA)
 
     if inverse:
+        sin_t *= -1
         u /= np.cos(inc)
-        up = u * cos_t + v * sin_t
-        vp = -u * sin_t + v * cos_t
-        return up, vp
 
     up = u * cos_t - v * sin_t
     vp = u * sin_t + v * cos_t
+
     #   Deproject
-    up *= np.cos(inc)
+    if not inverse:
+        up *= np.cos(inc)
 
     return up, vp
 

--- a/frank/geometry.py
+++ b/frank/geometry.py
@@ -49,7 +49,9 @@ def apply_phase_shift(u, v, V, dRA, dDec, inverse=False):
     dDec : float, unit = arcsec
         Phase shift in declination.
         NOTE: The sign convention is xx
-
+    inverse : bool, default=False
+        If True, the visibilities are uncentered (the phase shift undone)
+        rather than centered
     Returns
     -------
     shifted_vis : array of real, size = N, unit = Jy
@@ -61,7 +63,12 @@ def apply_phase_shift(u, v, V, dRA, dDec, inverse=False):
 
     phi = u * dRA + v * dDec
 
-    return V * (np.cos(phi) + 1j * np.sin(phi))
+    if inverse:
+        shifted_vis = V / (np.cos(phi) + 1j * np.sin(phi))
+    else:
+        shifted_vis = V * (np.cos(phi) + 1j * np.sin(phi))
+
+    return shifted_vis
 
 
 def deproject(u, v, inc, PA, inverse=False):
@@ -97,16 +104,15 @@ def deproject(u, v, inc, PA, inverse=False):
     sin_t = np.sin(PA)
 
     if inverse:
-        sin_t *= -1
+        u /= np.cos(inc)
+        up = u * cos_t + v * sin_t
+        vp = -u * sin_t + v * cos_t
+        return up, vp
 
     up = u * cos_t - v * sin_t
     vp = u * sin_t + v * cos_t
-
-    # Deproject
-    if inverse:
-        up /= np.cos(inc)
-    else:
-        up *= np.cos(inc)
+    #   Deproject
+    up *= np.cos(inc)
 
     return up, vp
 
@@ -161,10 +167,10 @@ class SourceGeometry(object):
             Corrected complex visibilites
 
         """
-        V = apply_phase_shift(u, v, V, self._dRA, self._dDec)
-        u, v = deproject(u, v, self._inc, self._PA)
+        Vp = apply_phase_shift(u, v, V, self._dRA, self._dDec)
+        up, vp = deproject(u, v, self._inc, self._PA)
 
-        return u, v, V
+        return up, vp, Vp
 
     def undo_correction(self, u, v, V):
         r"""
@@ -188,11 +194,10 @@ class SourceGeometry(object):
         Vp : array of real, size = N, unit = Jy
             Corrected complex visibilites
         """
+        up, vp = self.reproject(u, v)
+        Vp = apply_phase_shift(up, vp, V, self._dRA, self._dDec, inverse=True)
 
-        u, v = self.reproject(u, v)
-        vis = apply_phase_shift(u, v, V, -self._dRA, -self._dDec)
-
-        return u, v, V
+        return up, vp, Vp
 
     def deproject(self, u, v):
         """Convert uv-points from sky-plane to deprojected space"""
@@ -411,4 +416,6 @@ def _fit_geometry_gaussian(u, v, V, weights, phase_centre=None):
     if phase_centre is not None:
         dRA, dDec = phase_centre
 
-    return inc / deg_to_rad, PA / deg_to_rad, dRA, dDec
+    geometry = inc / deg_to_rad, PA / deg_to_rad, dRA, dDec
+
+    return geometry

--- a/frank/io.py
+++ b/frank/io.py
@@ -174,9 +174,9 @@ def save_fit(u, v, vis, weights, sol, prefix, save_solution=True,
         logging.info('    Saving fit and residual UVTables. N.B.: These will'
                      ' be of comparable size to your input UVTable')
 
-        V_pred = sol.predict(u, v)
+        u_reproj, v_reproj, V_pred = sol.predict(u, v, undo_deprojection=True)
 
         save_uvtable(prefix + '_frank_uv_fit.' + format,
-                     u, v, V_pred, weights)
+                     u_reproj, v_reproj, V_pred, weights)
         save_uvtable(prefix + '_frank_uv_resid.' + format,
-                     u, v, vis - V_pred, weights)
+                     u_reproj, v_reproj, vis - V_pred, weights)

--- a/frank/io.py
+++ b/frank/io.py
@@ -176,7 +176,7 @@ def save_fit(u, v, vis, weights, sol, prefix, save_solution=True,
 
         V_pred = sol.predict(u, v)
 
-        save_uvtable(prefix + '_frank_uv_fit2.' + format,
+        save_uvtable(prefix + '_frank_uv_fit.' + format,
                      u, v, V_pred, weights)
-        save_uvtable(prefix + '_frank_uv_resid2.' + format,
+        save_uvtable(prefix + '_frank_uv_resid.' + format,
                      u, v, vis - V_pred, weights)

--- a/frank/io.py
+++ b/frank/io.py
@@ -174,9 +174,9 @@ def save_fit(u, v, vis, weights, sol, prefix, save_solution=True,
         logging.info('    Saving fit and residual UVTables. N.B.: These will'
                      ' be of comparable size to your input UVTable')
 
-        u_reproj, v_reproj, V_pred = sol.predict(u, v, undo_deprojection=True)
+        V_pred = sol.predict(u, v)
 
-        save_uvtable(prefix + '_frank_uv_fit.' + format,
-                     u_reproj, v_reproj, V_pred, weights)
-        save_uvtable(prefix + '_frank_uv_resid.' + format,
-                     u_reproj, v_reproj, vis - V_pred, weights)
+        save_uvtable(prefix + '_frank_uv_fit2.' + format,
+                     u, v, V_pred, weights)
+        save_uvtable(prefix + '_frank_uv_resid2.' + format,
+                     u, v, vis - V_pred, weights)

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -278,7 +278,7 @@ class _HankelRegressor(object):
         return np.concatenate(V)
 
     def predict(self, u, v, I=None, geometry=None, block_size=10**5,
-                undo_deprojection=True):
+                undo_deprojection=False):
         r"""
         Predict the visibilities in the sky-plane
 
@@ -324,12 +324,12 @@ class _HankelRegressor(object):
             V *= np.cos(geometry.inc * deg_to_rad)
 
         if undo_deprojection:
-            # Undo deprojection and phase centering
+            # Return reprojected u, v, and phase-centered V
             u, v, V = geometry.undo_correction(u, v, V)
             return u, v, V
 
         else:
-            # Just undo phase centering
+            # Just return phase-centered V
             _, _, V = geometry.undo_correction(u, v, V)
             return V
 

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -277,8 +277,7 @@ class _HankelRegressor(object):
 
         return np.concatenate(V)
 
-    def predict(self, u, v, I=None, geometry=None, block_size=10**5,
-                undo_deprojection=False):
+    def predict(self, u, v, I=None, geometry=None, block_size=10**5):
         r"""
         Predict the visibilities in the sky-plane
 
@@ -296,9 +295,6 @@ class _HankelRegressor(object):
             fit will be used
         block_size : int, default = 10**5
             Maximum matrix size used in the visibility calculation
-        undo_deprojection: bool, default = True
-            Whether to return u and v reprojected (at the same coordinates as
-            an input UVTable, for example)
 
         Returns
         -------
@@ -323,15 +319,8 @@ class _HankelRegressor(object):
         if geometry is not None:
             V *= np.cos(geometry.inc * deg_to_rad)
 
-        if undo_deprojection:
-            # Return reprojected u, v, and phase-centered V
-            u, v, V = geometry.undo_correction(u, v, V)
-            return u, v, V
-
-        else:
-            # Just return phase-centered V
-            _, _, V = geometry.undo_correction(u, v, V)
-            return V
+        _, _, V = geometry.undo_correction(u, v, V)
+        return V
 
     def predict_deprojected(self, q=None, I=None, geometry=None,
                             block_size=10**5):

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -277,7 +277,8 @@ class _HankelRegressor(object):
 
         return np.concatenate(V)
 
-    def predict(self, u, v, I=None, geometry=None, block_size=10**5):
+    def predict(self, u, v, I=None, geometry=None, block_size=10**5,
+                undo_deprojection=True):
         r"""
         Predict the visibilities in the sky-plane
 
@@ -295,6 +296,9 @@ class _HankelRegressor(object):
             fit will be used
         block_size : int, default = 10**5
             Maximum matrix size used in the visibility calculation
+        undo_deprojection: bool, default = True
+            Whether to return u and v reprojected (at the same coordinates as
+            an input UVTable, for example)
 
         Returns
         -------
@@ -319,10 +323,15 @@ class _HankelRegressor(object):
         if geometry is not None:
             V *= np.cos(geometry.inc * deg_to_rad)
 
-        # Undo phase centering
-        _, _, V = geometry.undo_correction(u, v, V)
+        if undo_deprojection:
+            # Undo deprojection and phase centering
+            u, v, V = geometry.undo_correction(u, v, V)
+            return u, v, V
 
-        return V
+        else:
+            # Just undo phase centering
+            _, _, V = geometry.undo_correction(u, v, V)
+            return V
 
     def predict_deprojected(self, q=None, I=None, geometry=None,
                             block_size=10**5):

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -319,7 +319,9 @@ class _HankelRegressor(object):
         if geometry is not None:
             V *= np.cos(geometry.inc * deg_to_rad)
 
+        # Undo phase centering
         _, _, V = geometry.undo_correction(u, v, V)
+        
         return V
 
     def predict_deprojected(self, q=None, I=None, geometry=None,


### PR DESCRIPTION
In `geometry.deproject`, the ordering of the code needs to be amended as detailed in #93, and the return in `geometery.SourceGeometry.undo_correction` needs to be amended as detailed in #93, to correctly reproject the u,v coordinates and phase-unshift the visibilities. This PR makes these changes (verified as correct with multiple datasets). 

This PR also:
(1) updates the syntax in a few places in `geometry.py` so that it's consistent between functions, and so that function docstrings match the input and output variables.
(2) updates `radial_fitters._HankelRegressor.predict` to add the option to return the reprojected u and v in addition to the corresponding V. The default (and existing) behavior is just to return V, consistent with the `return` in `predict_deprojected`.
(3) following from (2), the PR updates `io.save_fit` to save the frank fit and residual UVTables as reprojected and phase-unshifted (this motivates, by convenience, adding the optional `return` in (2)). This prevents frank from saving fit and residual UVTables that always yield an image produced in CASA with the source centered at the origin, even if the source in the input UVTable isn't centered (which would notably make  the resulting residual image incorrect). 

Fixes #93 