### PR TITLE
update default max_iter

### DIFF
--- a/frank/default_parameters.json
+++ b/frank/default_parameters.json
@@ -31,7 +31,7 @@
     "p0"               : 1e-15,
     "wsmooth"          : 1e-4,
     "iter_tol"         : 1e-3,
-    "max_iter"         : 1500
+    "max_iter"         : 2000
   },
 
   "plotting" : {


### PR DESCRIPTION
this is why I always leave the house twice...

Changes `default_parameters.json` --> `hyperpriors: max_iter` from 1500 to 2000 to be consistent with #99 