### PR TITLE
Added python 3 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email="jmj51@ast.cam.ac.uk",
     description="Frankenstein, the flux reconstructor",
     long_description=open('README.md').read(),
+    python_requires='>=3',
     install_requires=[line.rstrip() for line in open("requirements.txt", "r").readlines()],
     extras_require={
         'test' : ['pytest'],


### PR DESCRIPTION
I've added the requirement of python >= 3 to setup.py. There is no good reason to support / allow python 2 since it is now no longer receiving security updates.

Closes #111 