### PR TITLE
Add note to docs on python3 requirement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,12 +33,6 @@ interpreting its results, and hosts the code's API.
     Github <https://github.com/discsim/frank>
     Submit an issue <https://github.com/discsim/frank/issues>
 
-Notes
-=====
-``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
-It also uses ``numpy``, ``scipy`` and ``matplotlib``
-(see the `requirements <https://github.com/discsim/frank/blob/master/requirements.txt>`_).
-
 License & attribution
 =====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ interpreting its results, and hosts the code's API.
 
 Notes
 =====
-``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
+``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x. It also uses ``numpy``, ``scipy`` and ``matplotlib`` (see ``requirements.txt``).
 
 License & attribution
 =====================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,10 @@ interpreting its results, and hosts the code's API.
     Github <https://github.com/discsim/frank>
     Submit an issue <https://github.com/discsim/frank/issues>
 
+Notes
+=====
+``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
+
 License & attribution
 =====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,9 @@ interpreting its results, and hosts the code's API.
 
 Notes
 =====
-``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x. It also uses ``numpy``, ``scipy`` and ``matplotlib`` (see ``requirements.txt``).
+``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
+It also uses ``numpy``, ``scipy`` and ``matplotlib``
+(see the `requirements <https://github.com/discsim/frank/blob/master/requirements.txt>`_).
 
 License & attribution
 =====================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,5 +1,6 @@
 Installation
 ============
+``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
 
 With pip
 --------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,6 @@
 Installation
 ============
-``frank`` requires Python >= 3.0 and does not support compatibility with Python 2.x.
+``frank`` requires Python 3 and is tested for Python 3.7. Usage under Python 2.x is not supported.
 
 With pip
 --------


### PR DESCRIPTION
This PR mentions explicitly in the docs main page that frank requires Python >= 3.0.