### PR TITLE
Exposed sub modules

### DIFF
--- a/frank/__init__.py
+++ b/frank/__init__.py
@@ -23,7 +23,7 @@ from frank import geometry
 from frank import hankel
 from frank import io
 from frank import radial_fitters
-from frank import tests
+from frank import utilities
 
 def enable_logging(log_file=None):
     """Turn on internal logging for Frankenstein

--- a/frank/__init__.py
+++ b/frank/__init__.py
@@ -18,6 +18,12 @@
 #
 __version__ = "0.1.0"
 
+from frank import constants
+from frank import geometry
+from frank import hankel
+from frank import io
+from frank import radial_fitters
+from frank import tests
 
 def enable_logging(log_file=None):
     """Turn on internal logging for Frankenstein

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@
 # coding=utf-8
 from setuptools import setup, find_packages
 
-version = {}
-exec(open("frank/__init__.py", "r").read(), version)
-version = version['__version__']
+with open("frank/__init__.py", "r") as f:
+    for line in f:
+        if line.startswith('__version__'):
+            version = line.split('=')[1].strip()
 
 setup(
     name="frank",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open("frank/__init__.py", "r") as f:
     for line in f:
         if line.startswith('__version__'):
-            version = line.split('=')[1].strip()
+            version = line.split('=')[1].strip().strip('"')
 
 setup(
     name="frank",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open("frank/__init__.py", "r") as f:
     for line in f:
         if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('"')
+            version = line.split('=')[1].strip().strip('"\'')
 
 setup(
     name="frank",


### PR DESCRIPTION
Without these lines `import frank` doesn't do anything useful. Since the code is small I don't see a reason not to import the core library at least.

I had to update setup.py to prevent from importing the submodules and hitting problems with the dependencies.