### PR TITLE
Placeholder for paper, DOI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://circleci.com/gh/discsim/frank">
       <img src="https://circleci.com/gh/discsim/frank.svg?style=shield">
   </a>    
-  
+
   <a href="https://discsim.github.io/frank/coverage/index.html">
       <img src="https://discsim.github.io/frank/coverage/badge.svg">
   </a>   
@@ -46,12 +46,12 @@ The [docs](https://discsim.github.io/frank/) have it all.
 
 Attribution
 -----------
-If you use **frank** for your research please cite Jennings, Booth, Tazzari et al. (2020) [[arXiv]](https://arxiv.org/xx)
-<!--MNRAS **xx** xx [[MNRAS]](xx) [[arXiv]](xx) [[ADS]](xx):
--->
+If you use **frank** for your research please cite Jennings, Booth, Tazzari et al. (2020, accepted). arXiv, ADS, MNRAS, Zenodo links coming soon!
+<!--[[arXiv]](https://arxiv.org/xx) MNRAS **xx** xx [[MNRAS]](xx) [[arXiv]](xx) [[ADS]](xx):
 ```
 xx
 ```
+-->
 
 Authors
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,10 +39,14 @@ License & attribution
 Frankenstein is free software licensed under the GPLv3 License.
 For more details see the `LICENSE <https://github.com/discsim/frank/blob/master/LICENSE.txt>`_.
 
-If you use frank for your research, please cite Jennings, Booth, Tazzari et al. (2020) MNRAS **xx** xx [`MNRAS <xx>`_] [`arXiv <xx>`_] [`ADS <xx>`_].
-The `Zenodo reference <https://zenodo.org/badge/latestdoi/xxx>`_ is  ::
+If you use frank for your research, please cite Jennings, Booth, Tazzari et al. (2020) MNRAS (accepted).
+arXiv, ADS, MNRAS, Zenodo links coming soon!
 
-    @misc{}xx update ADS bibtex entry xx
+.. **xx** xx [`MNRAS <xx>`_] [`arXiv <xx>`_] [`ADS <xx>`_].
+
+.. The `Zenodo reference <https://zenodo.org/badge/latestdoi/xxx>`_ is  ::
+
+..    @misc{}xx update ADS bibtex entry xx
 
 Authors
 -------


### PR DESCRIPTION
This PR updates links in the README and in the docs' index to start a sequence of v1.0 steps:

1. Merge this PR

2. Upload master to pypi as v1.0.0

3. Tag master as the v1.0.0 release on GitHub

4. I've already set up Zenodo. Once the release is tagged in the repo, Zenodo will archive the repo and assign a DOI. It'll generate a badge with the DPI; I'll make a PR to add this to the README and add the Zenodo reference to the docs' index.

5. I'll submit to arxiv today at 7pm UK time. When I have the permanent arxiv link Sunday night, I'll open a PR to add the arxiv permanent link to the README and index.

6. I'll repeat 5. for the ADS link and MNRAS link when I have them.

I think it's fine if the v1.0.0 pypi doesn't have the arxiv link. We can always tag and upload to pypi a v1.0.1 with the paper links; I'd rather get (1) - (4) done now.