### PR TITLE
Update docs typos, minor rephrasing, fix dead links

### DIFF
--- a/docs/py_API.rst
+++ b/docs/py_API.rst
@@ -26,7 +26,7 @@ the deprojected visibilities.
   :members: fit, MAP_solution, MAP_spectrum, MAP_spectrum_covariance, r, Rmax, q, Qmax, size, geometry
 
 .. autoclass:: frank.radial_fitters._HankelRegressor
-  :members: mean, covariance, power_spectrum, r, q, Rmax, Qmax, size, geometry, predict, log_likelihood
+  :members: mean, covariance, power_spectrum, r, q, Rmax, Qmax, size, geometry, predict, predict_deprojected, log_likelihood, solve_non_negative
 
 Utility functions and classes
 -----------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ That's it! frank saves (in `save_dir`) these fit outputs: |br|
 - the parameter file used in the fit as `<uvtable_filename>_frank_used_pars.json`, |br|
 - the fitted brightness profile as `<uvtable_filename>_frank_profile_fit.txt`, |br|
 - the visibility domain fit as `<uvtable_filename>_frank_vis_fit.npz`, |br|
-- the `sol` (solution) object (see `FrankFitter <https://github.com/discsim/frank/blob/master/frank/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter>`_) as `<uvtable_filename>_frank_sol.obj` and optionally the `iteration_diagnostics` object as `<uvtable_filename>_frank_iteration_diagnostics.obj`, |br|
+- the `sol` (solution) object (see `FrankFitter <py_API.rst#frank.radial_fitters.FrankFitter>`_) as `<uvtable_filename>_frank_sol.obj` and optionally the `iteration_diagnostics` object as `<uvtable_filename>_frank_iteration_diagnostics.obj`, |br|
 - UVTables for the **reprojected** fit and its residuals as `<uvtable_filename>_frank_uv_fit.npz` and `<uvtable_filename>_frank_uv_resid.npz`, |br|
 - figures showing the fit and its diagnostics as `<uvtable_filename>_frank_fit_quick.png`, `<uvtable_filename>_frank_fit_full.png` and optionally `<uvtable_filename>_frank_fit_diag.png`.
 
@@ -74,8 +74,8 @@ AS 209 (`Andrews et al. 2018 <https://ui.adsabs.harvard.edu/abs/2018ApJ...869L..
 **e)** As in (d), zooming on the longer baselines. |br|
 **f)** Residuals between the binned data and the fit. The residuals' RMSE is given in the legend;
 note this is being increased by the residuals beyond the baseline at which the fit walks off the data. |br|
-**g)** As in (d), on a log scale. The positive and negative data and fit regions are distinguished since this is a log scale.
-On this scale it is more apparent that frank walks off the visibilities as their binned noise begins to grow strongly at :math:`\approx 4\ {\rm M}\lambda`. |br|
+**g)** As in (d), on a log scale. The positive and negative data and fit regions are distinguished.
+On this scale it is more apparent that frank walks off the visibilities as their binned noise begins to grow strongly beyond :math:`\approx 4\ {\rm M}\lambda`. |br|
 **h)** The fit's reconstructed power spectrum, the prior on the fitted brightness profile. |br|
 **i)** Histogram of the binned real component of the visibilities.
 Note how the bin counts drop sharply beyond :math:`\approx 4.5\ {\rm M}\lambda`,
@@ -102,11 +102,12 @@ Understand the model's limitations
 See `this tutorial <tutorials/model_limitations.rst>`_ for an explanation and discussion of the model's limitations,
 briefly summarized here: |br|
 - Noise in the visibilities can imprint noise on the reconstructed brightness profile
-(in the above fit to AS 209, this is limited to the regions of flux :math:`\lesssim 10^9` Jy sr:math:`^{-1}`.). |br|
+(in the above fit to AS 209, this is limited to the regions of flux :math:`\lesssim 10^9` Jy sr :math:`^{-1}`). |br|
 - The fit does not  by default prevent regions of negative brightness in the reconstructed profile
-(seen in the AS 209 fit's innermost gap). |br|
+(as seen above in the AS 209 fit's innermost gap). |br|
 - The model yields a fitted brightness profile whose uncertainty is typically underestimated.
 For this reason we do not show the uncertainty by default (note its absence in the above AS 209 fit).
+See `here <tutorials/model_limitations.rst#an-underestimated-brightness-profile-uncertainty>`_ for a fuller discussion and mitigation approaches.
 
 Examine the fit's convergence
 #############################
@@ -127,13 +128,13 @@ Perform a fit using `frank` as a Python module
 -----------------------------------------------
 
 To interface with the code more directly, you can use it as a module.
-The wrapper functions in ``fit.py`` can do everything we'll show below for us,
-but  we're going to mostly avoid those here,
+The wrapper functions in ``fit.py`` do everything we'll show below,
+but we're going to mostly avoid those here,
 just to show how to directly interface with the code's internal classes.
 
 First import some basic stuff from frank and load the data
 (again using the DSHARP observations of AS 209, available as a UVTable
-`here <https://github.com/discsim/frank/blob/master/tutorials/AS209_continuum.npz>`_).
+`here <https://github.com/discsim/frank/blob/master/docs/tutorials/AS209_continuum.npz>`_).
 
 .. code-block:: python
 
@@ -148,8 +149,8 @@ First import some basic stuff from frank and load the data
     uvtable_filename = save_prefix + '.npz'
     u, v, vis, weights = load_data(uvtable_filename)
 
-Now run the fit using the `FrankFitter <https://github.com/discsim/frank/blob/master/frank/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter>`_ class.
-In this example we'll ask frank to fit for the disc's geometry using the `FitGeometryGaussian <https://github.com/discsim/frank/blob/master/frank/docs/_build/html/py_API.html#frank.geometry.FitGeometryGaussian>`_ class.
+Now run the fit using the `FrankFitter <py_API.rst#frank.radial_fitters.FrankFitter>`_ class.
+In this example we'll fit for the disc's geometry using the `FitGeometryGaussian <py_API.rst#frank.geometry.FitGeometryGaussian>`_ class.
 `FrankFitter` will then deproject the visibilities
 and fit for the brightness profile. We'll fit out to 1.6" using 250 collocation points and the code's default ``alpha`` and ``weights_smooth`` hyperparameter values.
 
@@ -160,7 +161,7 @@ and fit for the brightness profile. We'll fit out to 1.6" using 250 collocation 
 
     sol = FF.fit(u, v, vis, weights)
 
-Ok now make a simplified figure showing the fit (with only subplots (a), (b), (d), (f) from the full figure above;
+Now make a simplified figure showing the fit (with only subplots (a), (b), (d), (f) from the full figure above;
 when running from the terminal, frank produces this figure if `quick_plot=True` in your parameter file).
 
 .. code-block:: python

--- a/docs/tutorials/fit_convergence.rst
+++ b/docs/tutorials/fit_convergence.rst
@@ -6,7 +6,7 @@ Testing a fit's convergence
 ===========================
 If you'd like an in-depth look at how well a fit has converged,
 the fastest way is to run a fit from the terminal
-(see the `Quickstart <quickstart.rst>`_)
+(see the `Quickstart <../quickstart.rst>`_)
 and set `diag_plot=True` in your *.json* parameter file.
 This produces a diagnostic figure that, using the fit to the DSHARP observations
 of AS 209 from the Quickstart, looks like this,
@@ -16,26 +16,27 @@ of AS 209 from the Quickstart, looks like this,
    :figwidth: 700
 
 **a)** The fitted frank brightness profile over all fit iterations.
-Note how small amplitude, fast oscillations ('ringing') that are due to unconstrained
+Note how small amplitude, fast oscillations that are due to unconstrained
 baselines are damped over the first :math:`\approx 300` iterations.
 The fit runs until a convergence criterion on the power spectrum is met at every collocation point,
 :math:`|(P_{\rm i} - P_{\rm i-1}| \leq {\rm tol} * \pi`,
 where :math:`P_{\rm i}` is the power spectrum at iteration :math:`i`
 and :math:`{\rm tol}` is the tolerance (`iter_tol`) in your parameter file.
-This criterion is more robust than one based on the brightness profile because of the oscillations imposed on the latter by the visibilities' sparse sampling.
+This criterion is more robust than one based on the brightness profile because of the oscillations imposed on the latter by sparse sampling.
 If this stopping condition is not met, the fit runs until `max_iter` as set in your parameter file. |br|
 **b)** Sequential difference between the last 100 brightness profile iterations.
-So in this case the oscillations remaining at the end of the fit (:math:`\approx 1250` iterations) are at parts in :math:`10^6`.
+Note the y-scale here is in :math:`10^5\ {\rm Jy\ sr}^{-1}` (compared to :math:`10^{10}\ {\rm Jy\ sr}^{-1}` in (a)),
+so in this case the oscillations remaining at the end of the fit (:math:`\approx 1250` iterations) are at parts in :math:`10^6`.
 |br|
 **c)** The reconstructed power spectrum over all fit iterations.
 Our initial guess for the power spectrum, a power law with slope of -2, is apparent in the longest baselines for the first :math:`\approx 250` iterations,
 and then we continue iterating to suppress the high power placed at the data's noisiest, longest baselines. |br|
-**d)** Sequential difference between the last 100 brightness profile iterations.
-Note the y-scale here is small compared to (b),
-and the largest variation is at the baseline where the fit walks off the visibilities. |br|
+**d)** Sequential difference between the last 100 power spectrum iterations.
+Note the largest variation is at the baseline where the fit walks off the visibilities. |br|
 **e)** A simple metric for the brightness profile's convergence, :math:`{\rm max}(|(I_{\rm i} - I_{\rm i-1}|)\ /\ {\rm max}(I_i)`,
 where :math:`I_i` is the brightness profile at iteration :math:`i` and :math:`{\rm max}` entails the largest value across all collocation points.
 In this case the largest variation across all collocation points at the last iteration is thus at a part in :math:`10^6` of the profile's peak brightness, consistent with (b).
-We want to ensure this convergence metric isn't going start increasing again if we iterate for longer, so we wouldn't have wanted to stop at iteration :math:`\approx 750`,
+We always want to ensure this convergence metric isn't going start increasing again if we iterate for longer.
+So in this case we wouldn't have wanted to stop at iteration :math:`\approx 750`,
 while by iteration :math:`\approx 1000` the trend looks good. frank's internal stopping criterion for the fit, as described above in (a), is not yet met at
 iteration 1000, as that criterion is conservative to help ensure the power spectrum (and thus the brightness profile) is no longer appreciably changing.

--- a/docs/tutorials/fitting_mock_data.rst
+++ b/docs/tutorials/fitting_mock_data.rst
@@ -1,12 +1,12 @@
 Fitting mock data
 =================
 
-The process to fit a mock dataset is the same as a real dataset apart from one potential addition.
+The process to fit a mock dataset is the same as a real dataset, apart from one potential addition.
 If you've produced the mock visibilities with, e.g., a pipeline that emulates
 ALMA observations, you may not have an estimate of the weights on your individual visibilities.
 
 In this case you can set ``correct_weights=True`` in your parameter file.
 This will instruct frank to use the variance of the binned visibilities to
 *coarsely* estimate the pointwise weights
-(see the `estimate_weights <https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.utilities.estimate_weights>`_ function).
-This is done after deprojecting the visibilities and before fitting for the brightness profile.
+(see the `estimate_weights <../py_API.rst#frank.utilities.estimate_weights>`_ function).
+This is done between the steps to deproject the visibilities and fit for the brightness profile.

--- a/docs/tutorials/fitting_procedure.ipynb
+++ b/docs/tutorials/fitting_procedure.ipynb
@@ -43,12 +43,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As in the second example in the [Quickstart](../quickstart.rst) - where we use frank as a module - we'll import the internal classes [FrankFitter](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter) and [FitGeometryGaussian](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.FitGeometryGaussian) directly, in order to demonstrate their usage. Just note that `fit.py` uses the wrapper functions `deproject_disc` and `perform_fit` to call these, and more generally uses wrapper functions to do everything that we'll walk through more verbosely here."
+    "As in the second example in the [Quickstart](../quickstart.rst) - where we use frank as a module - we'll import the internal classes [FrankFitter](../py_API.rst#frank.radial_fitters.FrankFitter) and [FitGeometryGaussian](../py_API.rst#frank.geometry.FitGeometryGaussian) directly, in order to demonstrate their usage. Just note that `fit.py` uses the wrapper functions `deproject_disc` and `perform_fit` to call these, and more generally uses wrapper functions to do everything that we'll walk through more verbosely here."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,8 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Determinine the disc geometry and deproject the visibilities\n",
-    "<a id='determine_geometry'></a>"
+    "## 2. Determinine the disc geometry and deproject the visibilities"
    ]
   },
   {
@@ -99,11 +98,11 @@
    "metadata": {},
    "source": [
     "Before fitting the radial brightness profile, we need to determine the disc's geometry (inclination, position angle and phase center) in order to deproject the visibilities (recall that frank, fitting in 1D, assumes an axisymmetric source).\n",
-    "To do this we pass an object specifying how the geometry is determined to the [FrankFitter](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter) class.\n",
+    "To do this we pass an object specifying how the geometry is determined to the [FrankFitter](../py_API.rst#frank.radial_fitters.FrankFitter) class.\n",
     "\n",
-    "frank has three classes for this: [FixedGeometry](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.FixedGeometry) just takes a geometry you provide, [FitGeometryGaussian](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.FitGeometryGaussian) determines the geometry by fitting a 2D Gaussian directly to the visibilities, and [FitGeometryFourierBessel](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.FitGeometryFourierBessel) determines the geometry by fitting a nonparametric form. \n",
+    "frank has three classes for this: [FixedGeometry](../py_API.rst#frank.geometry.FixedGeometry) just takes a geometry you provide, [FitGeometryGaussian](../py_API.rst#frank.geometry.FitGeometryGaussian) determines the geometry by fitting a 2D Gaussian directly to the visibilities, and [FitGeometryFourierBessel](../py_API.rst#frank.geometry.FitGeometryFourierBessel) determines the geometry by fitting a nonparametric form. \n",
     "\n",
-    "`FitGeometryFourierBessel` is a more robust approach than `FitGeometryGaussian`, as the former fits for the geometry without making any assumptions about the functional form of the visibilities. There is a significant tradeoff in speed though; even for large datasets (of order $10^7$ visibilities), `FitGeometryGaussian` takes only $\\approx 30$ sec, while `FitGeometryFourierBessel` takes $> 10$ min. You can also supply your own geometry fitting routine (see [Sec.2.1](#own_geometry)).\n",
+    "`FitGeometryFourierBessel` is a more robust approach than `FitGeometryGaussian`, as the former fits for the geometry without making any assumptions about the functional form of the visibilities. There is a significant tradeoff in speed though; even for large datasets (of order $10^7$ visibilities), `FitGeometryGaussian` takes only $\\approx 30$ sec, while `FitGeometryFourierBessel` takes $> 10$ min. You can also supply your own geometry fitting routine (see Sec.2.1 below).\n",
     "\n",
     "For `FitGeometryGaussian` and `FitGeometryFourierBessel` you can choose to provide a known phase center if you _just_ want to fit for the inclination and PA (if running frank from the terminal, set `geometry : fit_phase_offset` to `false` in your parameter file and specify `dra` and `ddec` there). \n",
     "\n",
@@ -144,7 +143,7 @@
    "source": [
     "And let's plot the deprojected (u, v) coordinates and visibilities, just to verify that our correction had a reasonable effect. Note that `FrankFitter` (which we'll use below) deprojects the visibilities as a step in the fit; here we'll just redundantly deproject them to make the plot. \n",
     "\n",
-    "If running frank from the terminal, you can produce this figure just by setting `deprojec_plot` to `true` in your parameter file."
+    "If running frank from the terminal, you can produce this figure by setting `deprojec_plot` to `true` in your parameter file."
    ]
   },
   {
@@ -176,30 +175,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.1 Adding your own geometry fit routine \n",
-    "<a id='own_geometry'></a>"
+    "### 2.1 Adding your own geometry fit routine "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can extend frank's geometry fitting capabilities with your own routines by writing a class that inherits from the [SourceGeometry](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry) base class. This base class provides the interface used by frank to deproject the visibilities, but you do need to implement your own [fit()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.fit) method. This method will be called internally by `FrankFitter` to determine the geometry.\n",
+    "You can extend frank's geometry fitting capabilities with your own routines by writing a class that inherits from the [SourceGeometry](../py_API.rst#frank.geometry.SourceGeometry) base class. This base class provides the interface used by frank to deproject the visibilities, but you do need to implement your own [fit()](../py_API.rst#frank.geometry.SourceGeometry.fit) method. This method will be called internally by `FrankFitter` to determine the geometry.\n",
     "\n",
-    "The [fit()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.fit) method should set the attributes `_inc`,  `_PA`, `_dRA`, and `_dDec` -- in respective units of [deg], [deg], [arcsec], [arcsec] -- that are used by the\n",
-    "[apply_correction()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.apply_correction),\n",
-    "[undo_correction()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.undo_correction),\n",
-    "[deproject()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.deproject),\n",
+    "The `fit()` method should set the attributes `_inc`,  `_PA`, `_dRA`, and `_dDec` -- in respective units of [deg], [deg], [arcsec], [arcsec] -- that are used by the\n",
+    "[apply_correction()](../py_API.rst#frank.geometry.SourceGeometry.apply_correction),\n",
+    "[undo_correction()](../py_API.rst#frank.geometry.SourceGeometry.undo_correction),\n",
+    "[deproject()](../py_API.rst#frank.geometry.SourceGeometry.deproject),\n",
     "and\n",
-    "[reproject()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.geometry.SourceGeometry.reproject) methods."
+    "[reproject()](../py_API.rst#frank.geometry.SourceGeometry.reproject) methods."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Fit the deprojected visibilities for the brightness profile\n",
-    "<a id='fit_vis'></a>"
+    "## 3. Fit the deprojected visibilities for the brightness profile"
    ]
   },
   {
@@ -208,10 +205,10 @@
    "source": [
     "Ok, so we have the deprojected visibilities...let's fit 'em!\n",
     "\n",
-    "Objects used to perform a fit are in the `FrankFitter` class. In addition to the the `geom` object detailed in [Sec.2](#determine_geometry), five hyperparameters affect the fit: `Rmax` and `N`, which set the disc radius out to which the fit is performed and the number of collocation points used in the fit; and `alpha`, `p_0` and `weights_smooth`, the hyperprior parameters on the reconstructed power spectrum prior. \n",
+    "Objects used to perform a fit are in the `FrankFitter` class. In addition to the the `geom` object detailed in Sec.2, five hyperparameters affect the fit: `Rmax` and `N`, which set the disc radius out to which the fit is performed and the number of collocation points used in the fit; and `alpha`, `p_0` and `weights_smooth`, the hyperprior parameters on the power spectrum prior. \n",
     "See the frank methods paper for an explanation and interpretation of these five hyperparameters, and [this tutorial](./prior_sensitivity.ipynb) for a demonstration of how to test their effect on a given fit.\n",
     "\n",
-    "frank performs a fit with the `FrankFitter` class' [fit()](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter.fit) function. Let's use this with the `geom` object we generated above using the published geometry values, `Rmax = 1.6\"` appropriate for AS 209, `N = 250` to ensure we resolve narrow features in the brightness profile, and the default values `p_0 = 1e-15`, `alpha = 1.05` and `weights_smooth = 1e-4`. Recall that we'll only fit the real component of the visibilities, as frank is assuming an axisymmetric source that has zero imaginary component."
+    "frank performs a fit with the `FrankFitter` class' [fit()](../py_API.rst#frank.radial_fitters.FrankFitter.fit) function. Let's use this with the `geom` object we generated above using the published geometry values, `Rmax = 1.6\"` appropriate for AS 209, `N = 250` to ensure we resolve narrow features in the brightness profile, and the default values `p_0 = 1e-15` Jy$^2$, `alpha = 1.05` and `weights_smooth = 1e-4`. Recall that we'll only fit the real component of the visibilities, as frank is assuming an axisymmetric source that has zero imaginary component."
    ]
   },
   {
@@ -233,15 +230,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the fit is complete, the brightness profile's best fit parameters are returned and stored in the `FrankFitter` class' [MAP_solution](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter.MAP_solution) object (we called it `sol`). This provides:\n",
+    "Once the fit is complete, the brightness profile's best fit parameters are returned and stored in the `FrankFitter` class' [MAP_solution](../py_API.rst#frank.radial_fitters.FrankFitter.MAP_solution) object (we called it `sol` above). This provides:\n",
     "\n",
-    "- the posterior [mean](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.mean) and [covariance](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.covariance) for the reconstructed brightness profile; \n",
-    "- the fit's radius points [r](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.r) and corresponding frequency points [q](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.q); \n",
-    "- methods to compute the best fit model's visibilities at given (u, v) coordinates in either the sky plane with [predict](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.predict) or the deprojected plane with [predict_deprojected](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.predict_deprojected);\n",
-    "- and a method to evaluate the best fit model's [log_likelihood](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters._HankelRegressor.log_likelihood).\n",
+    "- the posterior [mean](../py_API.rst#frank.radial_fitters._HankelRegressor.mean) and [covariance](../py_API.rst#frank.radial_fitters._HankelRegressor.covariance) for the reconstructed brightness profile; \n",
+    "- the fit's radius points [r](../py_API.rst#frank.radial_fitters._HankelRegressor.r) and corresponding frequency points [q](../py_API.rst#frank.radial_fitters._HankelRegressor.q); \n",
+    "- methods to compute the best fit model's visibilities at given (u, v) coordinates in either the sky plane with [predict](../py_API.rst#frank.radial_fitters._HankelRegressor.predict) or the deprojected plane with [predict_deprojected](../py_API.rst#frank.radial_fitters._HankelRegressor.predict_deprojected);\n",
+    "- and a method to evaluate the best fit model's [log_likelihood](../py_API.rst#frank.radial_fitters._HankelRegressor.log_likelihood).\n",
     "\n",
     "Additionally the `FrankFitter` object we created (we called it `FF`) contains the power spectrum's best fit parameters:\n",
-    "- the maximum a posteriori power spectrum mean ([MAP_spectrum](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter.MAP_spectrum)) and covariance ([MAP_spectrum_covariance](https://github.com/discsim/frank/blob/master/docs/_build/html/py_API.html#frank.radial_fitters.FrankFitter.MAP_spectrum_covariance)).\n",
+    "\n",
+    "- the maximum a posteriori power spectrum mean ([MAP_spectrum](../py_API.rst#frank.radial_fitters.FrankFitter.MAP_spectrum)) and covariance ([MAP_spectrum_covariance](../py_API.rst#frank.radial_fitters.FrankFitter.MAP_spectrum_covariance)).\n",
     "\n"
    ]
   },
@@ -258,7 +256,7 @@
    "source": [
     "We could now save the fit results, including the `sol` object, with `save_fit(u, v, vis, weights, sol, prefix='AS209_continuum')`. We could also produce a full diagnostic figure and/or simplified figure of the fit. But since we've already done all this in the [Quickstart](../quickstart.rst), let's instead use the `sol` object to make a figure comparing the frank fitted brightness profile to the published CLEAN image-extracted profile ([Huang et al. 2018](https://ui.adsabs.harvard.edu/abs/2018ApJ...869L..42H/abstract)). \n",
     "\n",
-    "If running frank from the terminal, you can produce this figure just by passing in the path to a file with a CLEAN profile (or any comparison profile) to `compare_profile` and passing in the beam parameters (FWHM along both axes, position angle) to `clean_beam` in your parameter file."
+    "If running frank from the terminal, you can produce this figure by setting, in your parameter file, `compare_profile` to the path to a file with a CLEAN profile (or any comparison profile) and `clean_beam` to the beam parameters (FWHM along both axes, position angle)."
    ]
   },
   {
@@ -337,7 +335,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.6"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/tutorials/model_limitations.rst
+++ b/docs/tutorials/model_limitations.rst
@@ -5,8 +5,8 @@
 Examining the model's limitations
 =================================
 
-Noisy oscillations imprinted on brightness profile
---------------------------------------------------
+Noisy oscillations imprinted on the brightness profile
+------------------------------------------------------
 Regions in the visibilities with sparse and/or sufficiently noisy sampling can cause a lack of constraint on the local spatial frequency scale,
 inducing oscillations in the reconstructed brightness profile on the corresponding spatial scale.
 This can potentially mimic real structure.
@@ -19,7 +19,7 @@ is useful to assess and potentially suppress this behavior.
 Allowed regions of negative brightness
 --------------------------------------
 The fitted brightness profile can have negative regions corresponding to spatial scales un- or underconstrained by the visibilities.
-You can perform a fit in which the solution is forced to be positive (given the maximum a posteriori power spectrum) by using the `solve_non_negative` method provided by the solution returned by `FrankFitter` (if running frank from the terminal, set `hyperparameters : nonnegative` to `true` in your parameter file).
+You can perform a fit in which the solution is forced to be positive (given the maximum a posteriori power spectrum) by using the `solve_non_negative <../py_API.rst#frank.radial_fitters._HankelRegressor.solve_non_negative>`_ method provided by the solution returned by `FrankFitter` (if running frank from the terminal, set `hyperparameters : nonnegative` to `true` in your parameter file).
 In tests we've seen the effect on the recovered brightness profile to typically be localized to the regions of negative flux,
 with otherwise minor differences.
 Since enforcing the profile to be non-negative requires some extrapolation beyond the data's longest baseline,

--- a/docs/tutorials/prior_sensitivity.rst
+++ b/docs/tutorials/prior_sensitivity.rst
@@ -20,10 +20,9 @@ Note that the model's other three hyperparameters, :math:`R_{\rm max}`, :math:`N
 - :math:`N` is large enough to yield a grid of spatial frequency collocation points that extend beyond the longest baseline in the dataset
 (this also ensures the nominal fit resolution in real space is sufficiently sub-beam).
 Typical values are :math:`N = 100 - 300`. |br|
-- :math:`p_0` is small (:math:`0 < p_0 \ll 1`; the default is :math:`10^{-15}`).
+- :math:`p_0` is small (:math:`0 < p_0 \ll 1`; the default is :math:`10^{-15}` Jy :math:`^2`).
 
-.. See `this tutorial <./model_framework.rst>`_ for an extended discussion of the model's hyperparameters.
-See the frank methods paper for an extended discussion of the model's hyperparameters.
+See the frank `methods paper <https://academic.oup.com/mnras/advance-article/doi/10.1093/mnras/staa1365/5838058?guestAccessKey=7f163a1f-c12f-4771-8e54-928636794a5b>`_ for an extended discussion of the model's hyperparameters.
 
 Performing multiple fits to vary :math:`\alpha` and :math:`w_{\rm smooth}`
 --------------------------------------------------------------------------
@@ -57,7 +56,7 @@ The frank brightness profile for this dataset is evidently only weakly sensitive
 |br|
 **b)** As in (a), on a log scale.
 |br|
-**c)** The visibility domain fits, and the data in 1 and 50 :math:`kλ` bins.
+**c)** The visibility domain fits, and the data in 1 and 50 :math:`{\rm k}\lambda` bins.
 |br|
 **d)** As in (c), on a log scale, which shows the relatively small variation in how the fits
 handle the data as they become noise-dominated.
@@ -69,9 +68,9 @@ demonstrating the effect of the power spectrum as a prior is weak in this case.
 
 Always check a fit's sensitivity to :math:`\alpha` and :math:`w_{\rm smooth}`
 -----------------------------------------------------------------------------
-While these sensitivities are weak for datasets such as that shown here,
+While these sensitivities can be weak as shown above,
 a fit's sensitivity to :math:`\alpha` and :math:`w_{\rm smooth}` can be nontrivial
 for lower resolution or particularly noisy datasets.
 In these cases, the location and amplitude of substructure in the
 brightness profile can vary with :math:`\alpha` and :math:`w_{\rm smooth}`,
-so it's **always** worth checking how the fit changes in the ranges `alpha=[1.05, 1.30]` and `wsmooth=[1e-4, 1e-1]`.
+so it's **always** worth checking how the fit changes over the ranges `alpha=[1.05, 1.30]` and `wsmooth=[1e-4, 1e-1]`.

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -345,7 +345,7 @@ class _HankelRegressor(object):
             Geometry used to correct the visibilities for the source
             inclination. If not provided, the geometry determined during the
             fit will be used
-       block_size : int, default = 10**5
+        block_size : int, default = 10**5
             Maximum matrix size used in the visibility calculation
 
         Returns

--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -344,9 +344,9 @@ def estimate_weights(u, v, V, nbins=300, log=True, use_median=False):
 
     The estimation is done assuming that the variation in each bin is dominated
     by the noise. This will be true if:
-        1) The source is axi-symmetric,
-        2) The uv-points have been deprojected,
-        3) The bins are not too wide,
+    1) The source is axi-symmetric,
+    2) The uv-points have been deprojected,
+    3) The bins are not too wide,
     Otherwise the variance may be dominated by intrinsic variations in the
     visibilities.
 


### PR DESCRIPTION
This PR fixes a few typos in the docs, updates dead hyperlinks in the docs, and fixes the last of the `WARNING`s one gets when building the docs (`make html`).