### PR TITLE
Uvtable format

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,7 +14,8 @@ Perform a fit from the terminal
 To perform a quick fit from the terminal, only a UVTable with the data to
 be fit and a *.json* parameter file (see below) are needed. A UVTable can be extracted
 with CASA as demonstrated in `this tutorial <tutorials/mstable_to_uvtable.rst>`_.
-The column format should be `u [\lambda]     v [\lambda]      Re(V) [Jy]     Im(V) [Jy]     Weight [Jy^-2]`.
+The column format should be either `u [\lambda]     v [\lambda]      Re(V) [Jy]     Im(V) [Jy]     Weight [Jy^-2]`
+or `u [\lambda]     v [\lambda]      V (Re + Im * 1j) [Jy]     Weight [Jy^-2]`.
 
 You can quickly run a fit with the default parameter file, `default_parameters.json` (see below),
 by just passing in the filename of the UVTable to be fit with the `-uv` option. The UVTable can be a `.npz`, `.txt` or `.dat`.

--- a/frank/io.py
+++ b/frank/io.py
@@ -58,11 +58,10 @@ def load_uvtable(data_file):
 
     if extension in {'.txt', '.dat'}:
         u, v, re, im, weights = np.genfromtxt(data_file).T
-        vis = re + 1j*im
 
     elif extension == '.npz':
         dat = np.load(data_file)
-        u, v, vis, weights = [dat[i] for i in ['u', 'v', 'V', 'weights']]
+        u, v, re, im, weights = [dat[i] for i in ['u', 'v', 'ReV', 'ImV', 'weights']]
 
     else:
         raise ValueError("You provided a UVTable with the extension {}."
@@ -70,6 +69,8 @@ def load_uvtable(data_file):
                          " `.npz`. Formats .txt and .dat may optionally be"
                          " compressed (`.gz`, `.bz2`).".format(extension))
 
+    vis = re + 1j * im
+    
     return u, v, vis, weights
 
 
@@ -97,15 +98,14 @@ def save_uvtable(filename, u, v, vis, weights):
         header = 'u [lambda]\tv [lambda]\tRe(V)  [Jy]\tIm(V) [Jy]\tWeight [Jy^-2]'
 
         np.savetxt(filename,
-                   np.stack([u, v, vis.real, vis.imag,
-                             weights], axis=-1),
-                   header=header)
+                   np.stack([u, v, vis.real, vis.imag, weights], axis=-1),
+                            header=header)
 
     elif extension == '.npz':
         np.savez(filename,
-                 u=u, v=v, V=vis, weights=weights,
+                 u=u, v=v, ReV=vis.real, ImV=vis.imag, weights=weights,
                  units={'u': 'lambda', 'v': 'lambda',
-                        'V': 'Jy', 'weights': "Jy^-2"})
+                        'ReV': 'Jy', 'ImV': 'Jy', 'weights': "Jy^-2"})
 
 
 def save_fit(u, v, vis, weights, sol, prefix, save_solution=True,

--- a/frank/io.py
+++ b/frank/io.py
@@ -90,7 +90,7 @@ def load_uvtable(data_file):
     return u, v, vis, weights, ncols
 
 
-def save_uvtable(filename, u, v, vis, weights, ncols=5):
+def save_uvtable(filename, u, v, vis, weights, ncols=4):
     r"""Save a uvtable to file.
 
     Parameters

--- a/frank/tests.py
+++ b/frank/tests.py
@@ -280,12 +280,13 @@ def _run_pipeline(geometry='gaussian', fit_phase_offset=True, make_figs=False,
 
     u, v, re, im, weights = [AS209[k][::100] for k in ['u', 'v', 'ReV', 'ImV', 'weights']]
     vis = re + 1j * im
+    ncols = 5
     
     tmp_dir = '/tmp/frank/tests'
     os.makedirs(tmp_dir, exist_ok=True)
 
     uv_table = os.path.join(tmp_dir, 'small_uv.npz')
-    save_uvtable(uv_table, u, v, vis, weights)
+    save_uvtable(uv_table, u, v, vis, weights, ncols)
 
     # Build a parameter file
     params = fit.load_default_parameters()


### PR DESCRIPTION
I noticed the .npz UVTable column format (u, v, V, weights) differs from the .txt column format (u, v, Re, Im, weights). I think it best that the same column format is assumed (for loading and saving a UVTable) across all file extensions. So this PR just makes the five column format (separating V into Re and Im) the default. This is consistent with the documentation and I think the slightly less erorr-prone choice (e.g., a UVTable with the column V that stored the Im(V) component as a number _not_ multiplied by `1j` would currently silently result in an unexpected output from `io.load_uvtable` and `io.save_uvtable`).