### PR TITLE
Clarify UVTable column formats based on file extension

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,7 +14,10 @@ Perform a fit from the terminal
 To perform a quick fit from the terminal, only a UVTable with the data to
 be fit and a *.json* parameter file (see below) are needed. A UVTable can be extracted
 with CASA as demonstrated in `this tutorial <tutorials/mstable_to_uvtable.rst>`_.
-The column format should be `u [\lambda]     v [\lambda]      Re(V) [Jy]     Im(V) [Jy]     Weight [Jy^-2]`.
+The column format is assumed to be `u [\lambda]     v [\lambda]      Re(V) [Jy]     Im(V) [Jy]     Weight [Jy^-2]`
+if the UVTable is in ASCII format (`.txt` or `.dat`),
+or `u [\lambda]     v [\lambda]      V (Re + Im * 1j) [Jy]     Weight [Jy^-2]`
+if the UVTable is in binary format (`.npz`).
 
 You can quickly run a fit with the default parameter file, `default_parameters.json` (see below),
 by just passing in the filename of the UVTable to be fit with the `-uv` option. The UVTable can be a `.npz`, `.txt` or `.dat`.

--- a/frank/io.py
+++ b/frank/io.py
@@ -66,7 +66,7 @@ def load_uvtable(data_file):
         if not np.iscomplexobj(vis):
             raise ValueError("You provided a UVTable with the extension {}."
                              " This extension requires the UVTable's variable 'V' to be"
-                             " complex (of the form xx + yy * 1j).".format(extension))
+                             " complex (of the form Re(V) + Im(V) * 1j).".format(extension))
                 
     else:
         raise ValueError("You provided a UVTable with the extension {}."

--- a/frank/io.py
+++ b/frank/io.py
@@ -63,7 +63,11 @@ def load_uvtable(data_file):
     elif extension == '.npz':
         dat = np.load(data_file)
         u, v, vis, weights = [dat[i] for i in ['u', 'v', 'V', 'weights']]
-
+        if not np.iscomplexobj(vis):
+            raise ValueError("You provided a UVTable with the extension {}."
+                             " This extension requires the UVTable's variable 'V' to be"
+                             " complex (of the form xx + yy * 1j).".format(extension))
+                
     else:
         raise ValueError("You provided a UVTable with the extension {}."
                          " Please provide it as a `.txt`, `.dat`, `.npy`, or"


### PR DESCRIPTION
Clarify in `quickstart.rst`