### PR TITLE
fit.py: include call to alter_data if norm_wle is provided

### DIFF
--- a/frank/fit.py
+++ b/frank/fit.py
@@ -708,7 +708,8 @@ def main(*args):
     geom = determine_geometry(u, v, vis, weights, model)
 
     if model['modify_data']['baseline_range'] or \
-            model['modify_data']['correct_weights']:
+            model['modify_data']['correct_weights'] or \
+            model['modify_data']['norm_wle']:
         u, v, vis, weights = alter_data(
             u, v, vis, weights, geom, model)
 


### PR DESCRIPTION
`fit.py` wasn't checking whether `norm_wle` was provided in the parameter file in the conditional for whether to call `alter_data`. And it wouldn't be obvious to a user from the logging that this correction hasn't been applied.