### PR TITLE
estimate_weights flexibility

### DIFF
--- a/frank/default_parameters.json
+++ b/frank/default_parameters.json
@@ -13,6 +13,7 @@
   "modify_data" : {
     "baseline_range"   : null,
     "correct_weights"  : false,
+    "use_median_weight": false,
     "norm_wle"         : null
   },
 

--- a/frank/fit.py
+++ b/frank/fit.py
@@ -252,7 +252,8 @@ def alter_data(u, v, vis, weights, geom, model):
 
     if model['modify_data']['correct_weights']:
         up, vp = geom.deproject(u,v)
-        weights = utilities.estimate_weights(up, vp, vis, use_median=True)
+        weights = utilities.estimate_weights(up, vp, vis,
+                                            use_median=model['modify_data']['use_median_weight'])
 
     return u, v, vis, weights
 

--- a/frank/parameter_descriptions.json
+++ b/frank/parameter_descriptions.json
@@ -13,6 +13,7 @@
   "modify_data" : {
     "baseline_range"   : "(Deprojected) baseline range outside of which visibilities are truncated, unit=[\\lambda]",
     "correct_weights"  : "Whether to estimate the data's weights (as they may be unknown for mock data)",
+    "use_median_weight": "Whether to estimate all weights as the median binned visibility variance (or instead estimate weights using the baseline-dependent variance)"
     "norm_wle"         : "Wavelength (unit=[m]) by which to normalize the (u, v) points (i.e., convert from [m] to [rad]). Not needed if the (u, v) points are already in units of [\\lambda]"
   },
 

--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -403,7 +403,7 @@ def estimate_weights(u, v=None, V=None, nbins=300, log=True, use_median=False):
         second and third calls are equivalent to the first with u=0.
     """
 
-    logging.info('  Estimating visibility weights.')
+    logging.info('  Estimating visibility weights')
 
     if V is None:
         if v is not None:
@@ -434,8 +434,11 @@ def estimate_weights(u, v=None, V=None, nbins=300, log=True, use_median=False):
         var = uvBin.error.real**2 * uvBin.bin_counts
 
     if use_median:
+        logging.info('    Setting all weights as median binned visibility variance')
         return np.full(len(u), 1/np.median(var[uvBin.bin_counts > 1]))
     else:
+        logging.info('    Setting weights according to baseline-dependent binned'
+                     ' visibility variance')
         # For bins with 1 uv point, use the average of the adjacent bins
         no_var = np.argwhere(uvBin.bin_counts == 1).reshape(-1)
         if len(no_var) > 0:

--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -435,7 +435,7 @@ def estimate_weights(u, v=None, V=None, nbins=300, log=True, use_median=False):
 
     if use_median:
         logging.info('    Setting all weights as median binned visibility variance')
-        return np.full(len(u), 1/np.median(var[uvBin.bin_counts > 1]))
+        return np.full(len(u), 1/np.ma.median(var[uvBin.bin_counts > 1]))
     else:
         logging.info('    Setting weights according to baseline-dependent binned'
                      ' visibility variance')


### PR DESCRIPTION
This PR:

- Adds a parameter to the `default_parameters.json` to set the `use_median` flag in the call to `estimate_weights` in `fit.py`

- Sets the default in the `.json` to `false`, i.e., don't set all estimated weights as the single median variance across bins. I've found using the alternative, the baseline-dependent variance, to give a more sensible result for both the binned visibilities (by comparing 1 and 50 k\lambda binned Re(V)) and the corresponding frank fit for some datasets.

- Changes `np.median` to `np.ma.median` in `estimate_weights` to avoid a `MaskedArray` warning:
      ```
      python3.7/site-packages/numpy/core/fromnumeric.py:746: UserWarning: Warning: 'partition' will ignore the 'mask' of the MaskedArray.
  a.partition(kth, axis=axis, kind=kind, order=order)
      ```
I've verified this doesn't change the calculated median.