### PR TITLE
Prevent MaskedArray warning in plot_vis_quantity

### DIFF
--- a/frank/plot.py
+++ b/frank/plot.py
@@ -141,6 +141,14 @@ def plot_vis_quantity(baselines, vis_quantity, ax, vis_quantity_err=None,
         Uncertainty on vis_quantity values
     """
 
+    # If input arrays are masked with invalid values ('--'), replace those
+    # masked values with NaN
+    if np.ma.is_masked(baselines):
+        baselines = np.ma.array(baselines).filled(np.nan)
+        vis_quantity = np.ma.array(vis_quantity).filled(np.nan)
+        if vis_quantity_err is not None:
+            vis_quantity_err = np.ma.array(vis_quantity_err).filled(np.nan)
+
     if vis_quantity_err is not None:
         ax.errorbar(baselines, vis_quantity, yerr=vis_quantity_err, **kwargs)
     else:


### PR DESCRIPTION
This PR prevents a warning that was arising when plotting data from a `UVDataBinner` object,
```
python3.7/site-packages/numpy/core/_asarray.py:85: UserWarning: Warning: converting a masked element to nan.
  return array(a, dtype, copy=False, order=order)
```
We now check if the quantities being plotted are masked arrays, and if the masked values are `--` (as they are when using `np.ma.masked_where`). If so, new variables with those values converted to NaN are plotted.