### PR TITLE
more verbose _HankelRegressor overflow error message

### DIFF
--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -121,7 +121,12 @@ class _HankelRegressor(object):
             if np.any(p <= 0) or np.any(np.isnan(p)):
                 raise ValueError("Bad value in power spectrum. The power"
                                  " spectrum must be postive and not contain"
-                                 " any NaN values")
+                                 " any NaN values. This is likely due to"
+                                 " your UVtable (incorrect units or weights), "
+                                 " or the deprojection being applied (incorrect"
+                                 " geometry and/or phase center). Else you may"
+                                 " want to increase `rout` by 10-20% or `n` so"
+                                 " that it is large, >~300.")
 
             Ykm = self._DHT.coefficients()
             self._Sinv = np.einsum('ji,j,jk->ik', Ykm, 1/p, Ykm)
@@ -462,7 +467,7 @@ class FourierBesselFitter(object):
 
         self._blocking = block_data
         self._block_size = block_size
-        
+
         self._verbose = verbose
 
     def _check_uv_range(self, uv):

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -120,7 +120,7 @@ class _HankelRegressor(object):
         if p is not None:
             if np.any(p <= 0) or np.any(np.isnan(p)):
                 raise ValueError("Bad value in power spectrum. The power"
-                                 " spectrum must be postive and not contain"
+                                 " spectrum must be positive and not contain"
                                  " any NaN values. This is likely due to"
                                  " your UVtable (incorrect units or weights), "
                                  " or the deprojection being applied (incorrect"


### PR DESCRIPTION
A few people now have run into this error message when calling `FrankFitter`,

```
RuntimeWarning: overflow encountered in exp
  pi_new = np.exp(sparse_solve(Tij_pI, beta + np.log(pi)))
ValueError: Bad value in power spectrum. The power spectrum must be postive and not contain any NaN values
```

In all cases (including my own experience), this has been due to one of: 
- the UVtable passing in `u` and `v` in [m] rather than [\lambda],
- the UVtable weights being incorrect (due to some aspect of extracting the UVtable from CASA), 
- the geometry/phase center used for the deprojection being pretty wrong, 
- or more rarely the fit's `rout` and/or `n` needing to be increased.

This PR just makes the above error message more verbose to help point people to these likely underlying causes.