### PR TITLE
correct colorscale for 2d sweeps in figures

### DIFF
--- a/frank/make_figs.py
+++ b/frank/make_figs.py
@@ -304,10 +304,11 @@ def make_quick_fig(u, v, vis, weights, sol, bin_widths, dist=None, logx=True,
             err = ValueError("Unknown 'stretch'. Should be one of 'power' or 'asinh'")
             raise err
 
-        plot_2dsweep(sol.r, sol.mean, ax=ax4, cmap='inferno', norm=norm, vmin=vmin,
-                    vmax=vmax / 1e10, project=False)
-        plot_2dsweep(sol.r, sol.mean, ax=ax5, cmap='inferno', norm=norm, vmin=vmin,
-                    vmax=vmax / 1e10, project=True, geom=sol.geometry)
+        plot_2dsweep(sol.r, sol.mean, ax=ax4, cmap='inferno', norm=norm,
+                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=False)
+        plot_2dsweep(sol.r, sol.mean, ax=ax5, cmap='inferno', norm=norm,
+                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=True,
+                    geom=sol.geometry)
 
         ax1.set_xlabel('r ["]')
         ax0.set_ylabel(r'Brightness [$10^{10}$ Jy sr$^{-1}$]')
@@ -539,8 +540,9 @@ def make_full_fig(u, v, vis, weights, sol, bin_widths, alpha, wsmooth,
             err = ValueError("Unknown 'stretch'. Should be one of 'power' or 'asinh'")
             raise err
 
-        plot_2dsweep(sol.r, sol.mean, ax=ax2, cmap='inferno', norm=norm, vmin=vmin,
-                    vmax=vmax / 1e10, project=True, geom=sol.geometry)
+        plot_2dsweep(sol.r, sol.mean, ax=ax2, cmap='inferno', norm=norm,
+                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=True,
+                    geom=sol.geometry)
 
         ax1.set_xlabel('r ["]')
         ax0.set_ylabel(r'Brightness [$10^{10}$ Jy sr$^{-1}$]')

--- a/frank/make_figs.py
+++ b/frank/make_figs.py
@@ -305,9 +305,9 @@ def make_quick_fig(u, v, vis, weights, sol, bin_widths, dist=None, logx=True,
             raise err
 
         plot_2dsweep(sol.r, sol.mean, ax=ax4, cmap='inferno', norm=norm,
-                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=False)
+                    vmin=vmin, vmax=vmax, project=False)
         plot_2dsweep(sol.r, sol.mean, ax=ax5, cmap='inferno', norm=norm,
-                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=True,
+                    vmin=vmin, vmax=vmax, project=True,
                     geom=sol.geometry)
 
         ax1.set_xlabel('r ["]')
@@ -541,7 +541,7 @@ def make_full_fig(u, v, vis, weights, sol, bin_widths, alpha, wsmooth,
             raise err
 
         plot_2dsweep(sol.r, sol.mean, ax=ax2, cmap='inferno', norm=norm,
-                    vmin=vmin / 1e10, vmax=vmax / 1e10, project=True,
+                    vmin=vmin, vmax=vmax, project=True,
                     geom=sol.geometry)
 
         ax1.set_xlabel('r ["]')
@@ -886,10 +886,10 @@ def make_clean_comparison_fig(u, v, vis, weights, sol, clean_profile,
             raise err
 
         plot_2dsweep(sol.r, sol.mean, ax=ax2, cmap='inferno', norm=norm, vmin=0,
-                    vmax=vmax / 1e10, xmax=sol.Rmax, plot_colorbar=True)
+                    vmax=vmax, xmax=sol.Rmax, plot_colorbar=True)
         if mean_convolved is not None:
             plot_2dsweep(sol.r, mean_convolved, ax=ax3, cmap='inferno', norm=norm,
-                        vmin=0, vmax=vmax / 1e10, xmax=sol.Rmax, plot_colorbar=True)
+                        vmin=0, vmax=vmax, xmax=sol.Rmax, plot_colorbar=True)
 
         # Interpolate the CLEAN profile onto the frank grid to ensure the CLEAN
         # swept 'image' has the same pixel resolution as the frank swept 'images'
@@ -897,7 +897,7 @@ def make_clean_comparison_fig(u, v, vis, weights, sol, clean_profile,
         interp = interp1d(clean_profile['r'], clean_profile['I'])
         regrid_I_clean = interp(sol.r)
         plot_2dsweep(sol.r, regrid_I_clean, ax=ax4, cmap='inferno', norm=norm,
-                    vmin=0, vmax=vmax / 1e10, xmax=sol.Rmax, plot_colorbar=True)
+                    vmin=0, vmax=vmax, xmax=sol.Rmax, plot_colorbar=True)
 
         ax0.legend(loc='best')
         ax1.legend(loc='best')

--- a/frank/plot.py
+++ b/frank/plot.py
@@ -315,7 +315,8 @@ def plot_pwr_spec_iterations(q, pwr_spec_iter, n_iter, ax,
 
 
 def plot_2dsweep(r, I, ax, cmap='inferno', norm=None, vmin=None,
-                 vmax=None, xmax=None, ymax=None, dr=None, plot_colorbar=True,
+                 vmax=None, xmax=None, ymax=None, dr=None,
+                 rescale_brightness=True, plot_colorbar=True,
                  project=False, phase_shift=False, geom=None, **kwargs):
     r"""
     Plot a radial profile swept over :math:`2 \pi` to produce an image
@@ -344,6 +345,8 @@ def plot_2dsweep(r, I, ax, cmap='inferno', norm=None, vmin=None,
     dr : float, optional, default = None
         Pixel size (same units as r). If not provided, it will be set at the
         same spatial scale as r
+    rescale_brightness : bool, default = True
+        Whether to rescale the image and colorbar brightness by a factor of 10^{10}
     plot_colorbar: bool, default = True
         Whether to plot a colorbar beside the image
     project : bool, default = False
@@ -368,7 +371,10 @@ def plot_2dsweep(r, I, ax, cmap='inferno', norm=None, vmin=None,
     if ymax is None:
         ymax = ymax_computed
 
-    I2D /= 1e10
+    if rescale_brightness:
+        I2D /= 1e10
+        vmin /= 1e10
+        vmax /= 1e10
 
     if vmin is None:
         vmin = I2D.min()
@@ -389,4 +395,7 @@ def plot_2dsweep(r, I, ax, cmap='inferno', norm=None, vmin=None,
         m.set_array([])
 
         cbar = plt.colorbar(m, ax=ax, orientation='vertical', shrink=.7)
-        cbar.set_label(r'I [$10^{10}$ Jy sr$^{-1}$]')
+        if rescale_brightness:
+            cbar.set_label(r'I [$10^{10}$ Jy sr$^{-1}$]')
+        else:
+            cbar.set_label(r'I [Jy sr$^{-1}$]')


### PR DESCRIPTION
Fixes minor bug that applied wrong scaling to colorbars in `make_quick_fig`, `make_full_fig`