### PR TITLE
total flux rescaling 

### DIFF
--- a/frank/default_parameters.json
+++ b/frank/default_parameters.json
@@ -25,7 +25,8 @@
     "inc"              : 0.0,
     "pa"               : 0.0,
     "dra"              : 0.0,
-    "ddec"             : 0.0
+    "ddec"             : 0.0,
+    "rescale_flux"     : true
   },
 
   "hyperparameters" : {

--- a/frank/fit.py
+++ b/frank/fit.py
@@ -394,7 +394,8 @@ def perform_fit(u, v, vis, weights, geom, model):
                                     weights_smooth=model['hyperparameters']['wsmooth'],
                                     tol=model['hyperparameters']['iter_tol'],
                                     max_iter=model['hyperparameters']['max_iter'],
-                                    store_iteration_diagnostics=need_iterations
+                                    store_iteration_diagnostics=need_iterations,
+                                    face_on_rescale=model['geometry']['rescale_flux']
                                     )
 
     sol = FF.fit(u, v, vis, weights)
@@ -523,7 +524,7 @@ def output_results(u, v, vis, weights, sol, geom, model, iteration_diagnostics=N
     axes : Matplotlib `~.axes.Axes` class
         Axes for each of the produced figures
     """
-
+    
     io.save_fit(u, v, vis, weights, sol,
                 model['input_output']['save_prefix'],
                 model['input_output']['save_solution'],

--- a/frank/geometry.py
+++ b/frank/geometry.py
@@ -149,10 +149,12 @@ def rescale_total_flux(V, weights, inc):
     Notes
     -----
     This scaling accounts for the difference between the inclined (observed)
-    brightness and the assumed face-on brightness (this implicitly assumes the
-    emission is optically thick). The source's integrated (2D) flux is assumed
+    brightness and the assumed face-on brightness, assuming the
+    emission is optically thick. The source's integrated (2D) flux is assumed
     to be
         :math:`F = \cos(i) \int_r^{r=R}{I(r) 2 \pi r dr}`.
+    No rescaling would be appropriate in the optically thin limit (e.g., for
+    a debris disc).
     """
 
     # Ensure we're only altering the real component of the visibilities

--- a/frank/parameter_descriptions.json
+++ b/frank/parameter_descriptions.json
@@ -25,7 +25,8 @@
     "inc"              : "Inclination, unit=[deg]",
     "pa"               : "Position angle, defined east of north, unit=[deg]",
     "dra"              : "Delta (offset from 0) right ascension, defined positive for offsets toward east, unit=[arcsec]",
-    "ddec"             : "Delta declination, unit=[arcsec]"
+    "ddec"             : "Delta declination, unit=[arcsec]",
+    "rescale_flux"     : "Whether to rescale the total flux to account for the source's inclination (see frank.geometry.rescale_total_flux)"        
   },
 
   "hyperparameters" : {

--- a/frank/radial_fitters.py
+++ b/frank/radial_fitters.py
@@ -452,7 +452,7 @@ class FourierBesselFitter(object):
         elements.
     block_size : int, default = 10**5
         Size of the matrices if blocking is used
-    face_on_rescale : bool, default = True
+    assume_optically_thick : bool, default = True
         Whether to correct the visibility amplitudes by a factor of
         1 / cos(inclination); see frank.geometry.rescale_total_flux
     verbose : bool, default = False
@@ -460,7 +460,7 @@ class FourierBesselFitter(object):
     """
 
     def __init__(self, Rmax, N, geometry, nu=0, block_data=True,
-                 block_size=10 ** 5, face_on_rescale=True, verbose=True):
+                 block_size=10 ** 5, assume_optically_thick=True, verbose=True):
 
         Rmax /= rad_to_arcsec
 
@@ -471,7 +471,7 @@ class FourierBesselFitter(object):
         self._blocking = block_data
         self._block_size = block_size
 
-        self._face_on_rescale = face_on_rescale
+        self._assume_optically_thick = assume_optically_thick
 
         self._verbose = verbose
 
@@ -502,16 +502,16 @@ class FourierBesselFitter(object):
         V = V.real
 
         # Rescale visibility amplitudes to account for total flux
-        if self._face_on_rescale:
+        if self._assume_optically_thick:
             if self._verbose:
-                logging.info('    face_on_rescale=True (the default): Scaling '
-                             'the total flux to account for the source '
+                logging.info('    assume_optically_thick=True (the default): '
+                             ' Scaling the total flux to account for the source '
                              'inclination')
             V, weights = self._geometry.rescale_total_flux(V, weights)
 
         else:
             if self._verbose:
-                logging.info('    face_on_rescale=False: *Not* scaling the '
+                logging.info('    assume_optically_thick=False: *Not* scaling the '
                              'total flux to account for the source inclination')
 
         # If blocking is used, we will build up M and j chunk-by-chunk
@@ -656,7 +656,7 @@ class FrankFitter(FourierBesselFitter):
     store_iteration_diagnostics: bool, default = False
         Whether to store the power spectrum parameters and brightness profile
         for each fit iteration
-    face_on_rescale : bool, default = True
+    assume_optically_thick : bool, default = True
         Whether to correct the visibility amplitudes by a factor of
         1 / cos(inclination); see frank.geometry.rescale_total_flux
     verbose:
@@ -673,11 +673,11 @@ class FrankFitter(FourierBesselFitter):
     def __init__(self, Rmax, N, geometry, nu=0, block_data=True,
                  block_size=10 ** 5, alpha=1.05, p_0=1e-15, weights_smooth=1e-4,
                  tol=1e-3, max_iter=2000, check_qbounds=True,
-                 store_iteration_diagnostics=False, face_on_rescale=True,
+                 store_iteration_diagnostics=False, assume_optically_thick=True,
                  verbose=True):
 
         super(FrankFitter, self).__init__(Rmax, N, geometry, nu, block_data,
-                                          block_size, face_on_rescale, verbose)
+                                          block_size, assume_optically_thick, verbose)
 
         self._p0 = p_0
         self._ai = alpha


### PR DESCRIPTION
Per Marco's suggestion, this PR makes it explicit in the docs that we're applying a flux rescaling (I've left this the default behavior to avoid user confusion when reproducing previous frank fits). The PR also separates the flux rescaling into its own method in `geometry`, and makes the rescaling optional in `FourierBesselFitter`.