### PR TITLE
Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
       - name: Checkout code
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install
         run: pip install .
-        
+
       - name: Run unit tests
         run: |
           mkdir -p test-reports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Intended Audience :: Science/Research
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -36,7 +35,7 @@ keywords =
 packages = frank
 
 # python_requires docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-python_requires = >=3.6
+python_requires = >=3.7
 
 # PEP 440 - pinning package versions: https://www.python.org/dev/peps/pep-0440/#compatible-release
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords =
     science
     astronomy

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 keywords =
     science
     astronomy

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Intended Audience :: Science/Research
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -35,7 +36,7 @@ keywords =
 packages = frank
 
 # python_requires docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-python_requires = >=3.7
+python_requires = >=3.6
 
 # PEP 440 - pinning package versions: https://www.python.org/dev/peps/pep-0440/#compatible-release
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ python_requires = >=3.6
 install_requires =
     numpy>=1.12
     matplotlib>=3.1.0
-    scipy>=0.18.0
+    scipy>=1.2.0
 
 # extras_require syntax:
 # https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html?highlight=options.extras_require#configuring-setup-using-setup-cfg-files


### PR DESCRIPTION
- Adds Python 3.10, 3.11 (most recent versions) to tests
- Removes support for python 3.6 (it's several months past end-of-life -- https://www.python.org/dev/peps/pep-0440/#compatible-release)
- Updates minimum scipy version (it was only 0.18, the most recent version is 1.9)