### PR TITLE
Include non-py files in install

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Changelog
 +++++++++
 
+v.1.2.1
++++++++
+*Fixed a bug that caused non-python files to not be installed through pip*
+
 v.1.2.0
 +++++++
 *Introduction of log-normal fits, large amount of code refactoring to support both 'Gaussian' and 'LogNormal' methods*

--- a/frank/__init__.py
+++ b/frank/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>
 #
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from frank import constants
 from frank import geometry

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,15 +34,17 @@ keywords =
 
 [options]
 packages = frank
-
 # python_requires docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
 python_requires = >=3.6
-
 # PEP 440 - pinning package versions: https://www.python.org/dev/peps/pep-0440/#compatible-release
 install_requires =
     numpy>=1.12
     matplotlib>=3.1.0
     scipy>=1.2.0
+
+# additional files to include in install
+[options.package_data]
+* = default_parameters.json, parameter_descriptions.json, frank.mplstyle
 
 # extras_require syntax:
 # https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html?highlight=options.extras_require#configuring-setup-using-setup-cfg-files


### PR DESCRIPTION
The `setup` was changed in frank v.1.2.0, moving everything from `setup.py` to `setup.cfg`. The syntax is slightly different, and it resulted in the non-python files (the `.json` files and the matplotlib style file) in the `frank` source dir not being included in the pip release (even though they're specified in the `MANIFEST`). This is subtle; `python setup.py sdist` shows these files included in the distribution, but they're not copied into the frank source dir when the package is pip installed. I fixed this and suggest this PR update the code to v1.2.1 so I can issue a new pypi release. 