### PR TITLE
Fix for github actions update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
 
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # download the previously uploaded 'built_docs' artifact
       - name: Download docs artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Intended Audience :: Science/Research
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -35,7 +34,7 @@ keywords =
 [options]
 packages = frank
 # python_requires docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-python_requires = >=3.6
+python_requires = >=3.7
 # PEP 440 - pinning package versions: https://www.python.org/dev/peps/pep-0440/#compatible-release
 install_requires =
     numpy>=1.12


### PR DESCRIPTION
Github has made a couple of changes to actions that has resulted in errors for frank:
1. Removing support for python3.6
2. Removing support for node.js 12, used by some actions within the frank process.

I've fixed these by 1. removing python3.6 from the tests and 2. updating to newer versions of the actions. The tests are now passing.