### PR TITLE
Simplify fig functions

### DIFF
--- a/frank/fit.py
+++ b/frank/fit.py
@@ -567,13 +567,6 @@ def output_results(u, v, vis, weights, sol, geom, model, iteration_diagnostics=N
 
         logging.info('  Plotting results')
 
-        priors = {'alpha': sol.info['alpha'],\
-                  'wsmooth': sol.info['wsmooth'],\
-                  'Rmax': sol.info['Rmax'],\
-                  'N': sol.info['N'],\
-                  'p0': sol.info['p0']
-                  }
-
         if model['plotting']['deprojec_plot']:
             deproj_fig, deproj_axes = make_figs.make_deprojection_fig(u=u, v=v,
                                                              vis=vis, weights=weights,
@@ -590,7 +583,6 @@ def output_results(u, v, vis, weights, sol, geom, model, iteration_diagnostics=N
             quick_fig, quick_axes = make_figs.make_quick_fig(u=u, v=v, vis=vis,
                                                              weights=weights, sol=sol,
                                                              bin_widths=model['plotting']['bin_widths'],
-                                                             priors=priors,
                                                              dist=model['plotting']['distance'],
                                                              logx=model['plotting']['plot_in_logx'],
                                                              force_style=model['plotting']['force_style'],
@@ -607,7 +599,6 @@ def output_results(u, v, vis, weights, sol, geom, model, iteration_diagnostics=N
             full_fig, full_axes = make_figs.make_full_fig(u=u, v=v, vis=vis,
                                                           weights=weights, sol=sol,
                                                           bin_widths=model['plotting']['bin_widths'],
-                                                          priors=priors,
                                                           dist=model['plotting']['distance'],
                                                           logx=model['plotting']['plot_in_logx'],
                                                           force_style=model['plotting']['force_style'],

--- a/frank/make_figs.py
+++ b/frank/make_figs.py
@@ -174,7 +174,7 @@ def make_deprojection_fig(u, v, vis, weights, geom, bin_widths, logx=False,
     return fig, axes
 
 
-def make_quick_fig(u, v, vis, weights, sol, bin_widths, priors, dist=None,
+def make_quick_fig(u, v, vis, weights, sol, bin_widths, dist=None,
                    logx=False, force_style=True, save_prefix=None,
                    stretch='power', gamma=1.0, asinh_a=0.02, figsize=(8,6)):
     r"""
@@ -194,9 +194,6 @@ def make_quick_fig(u, v, vis, weights, sol, bin_widths, priors, dist=None,
         (see frank.radial_fitters.FrankFitter)
     bin_widths : list, unit = \lambda
         Bin widths in which to bin the observed visibilities
-    priors : dict
-        Dictionary with fit hyperparameters: 'alpha', 'wsmooth', 'Rmax', 'N', 'p0'.
-        Used for figure title
     dist : float, optional, unit = AU, default = None
         Distance to source, used to show second x-axis in [AU]
     logx : bool, default = False
@@ -227,8 +224,7 @@ def make_quick_fig(u, v, vis, weights, sol, bin_widths, priors, dist=None,
 
     logging.info('    Making quick figure')
 
-    alpha, wsmooth, Rmax, N, p0 = priors['alpha'], priors['wsmooth'],\
-                                  priors['Rmax'], priors['N'], priors['p0']
+    Rmax, N, alpha, wsmooth, p0 = sol._info.values()
 
     with frank_plotting_style_context_manager(force_style):
         gs = GridSpec(3, 2, hspace=0, bottom=.12)
@@ -350,7 +346,7 @@ def make_quick_fig(u, v, vis, weights, sol, bin_widths, priors, dist=None,
     return fig, axes
 
 
-def make_full_fig(u, v, vis, weights, sol, bin_widths, priors,
+def make_full_fig(u, v, vis, weights, sol, bin_widths,
                   dist=None, logx=False, force_style=True,
                   save_prefix=None, norm_residuals=False, stretch='power',
                   gamma=1.0, asinh_a=0.02, figsize=(8, 6)):
@@ -371,9 +367,6 @@ def make_full_fig(u, v, vis, weights, sol, bin_widths, priors,
         (see frank.radial_fitters.FrankFitter)
     bin_widths : list, unit = \lambda
         Bin widths in which to bin the observed visibilities
-    priors : dict
-        Dictionary with fit hyperparameters: 'alpha', 'wsmooth', 'Rmax', 'N', 'p0'.
-        Used for figure title
     dist : float, optional, unit = AU, default = None
         Distance to source, used to show second x-axis in [AU]
     logx : bool, default = False
@@ -407,8 +400,7 @@ def make_full_fig(u, v, vis, weights, sol, bin_widths, priors,
 
     logging.info('    Making full figure')
 
-    alpha, wsmooth, Rmax, N, p0 = priors['alpha'], priors['wsmooth'],\
-                                  priors['Rmax'], priors['N'], priors['p0']
+    Rmax, N, alpha, wsmooth, p0 = sol._info.values()
 
     with frank_plotting_style_context_manager(force_style):
         gs = GridSpec(3, 3, hspace=0, wspace=0.25, left=0.06, right=0.98)


### PR DESCRIPTION
The functions in `make_figs` are...blah. This PR makes one small change that saves annoyance, deleting the unneeded `priors` arg in a couple figures. 