### PR TITLE
Add `I_scale` arg to `.json`s

### DIFF
--- a/frank/default_parameters.json
+++ b/frank/default_parameters.json
@@ -39,7 +39,8 @@
     "max_iter"         : 2000,
     "converge_failure" : "warn",
     "nonnegative"      : true,
-    "method"           : "Normal"
+    "method"           : "Normal",
+    "I_scale"          : 1e5
   },
 
   "plotting" : {

--- a/frank/fit.py
+++ b/frank/fit.py
@@ -413,6 +413,7 @@ def perform_fit(u, v, vis, weights, geom, model):
                                     weights_smooth=model['hyperparameters']['wsmooth'],
                                     tol=model['hyperparameters']['iter_tol'],
                                     method=model['hyperparameters']['method'],
+                                    I_scale=model['hyperparameters']['I_scale'],
                                     max_iter=model['hyperparameters']['max_iter'],
                                     store_iteration_diagnostics=need_iterations,
                                     assume_optically_thick=model['geometry']['rescale_flux'],

--- a/frank/parameter_descriptions.json
+++ b/frank/parameter_descriptions.json
@@ -39,7 +39,8 @@
     "max_iter"         : "Maximum number of fit iterations",
     "converge_failure" : "How to treat the case when the fit does not reach convergence by 'max_iter': one of ['raise', 'warn', 'ignore'] to respectively raise an error, raise a warning, or ignore.",    
     "nonnegative"      : "Whether the best-fit nonnegative brightness profile is included in the frank fit solution object",
-    "method"           : "The fit method: 'Normal' to fit in linear brighness, 'LogNormal' to fit in logarithmic brightness"
+    "method"           : "The fit method: 'Normal' to fit in linear brighness, 'LogNormal' to fit in logarithmic brightness",
+    "I_scale"          :  "Brightness scale, unit=[Jy/sr]. Only used if 'method' is 'LogNormal' -- the 'LogNormal' model produces I('rout') = 'I_scale'"
   },
 
   "plotting" : {


### PR DESCRIPTION
For command-line fits with the `LogNormal` model, the `I_scale` parameter is useful to pass through the `.json` parameter file (for sufficiently faint sources such as some debris disks, the default `I_scale = 1e5` in `FrankFitter` can be too large). PR adds this arg to the `.json`s and the fit pipeline in `fit.py`.