### PR TITLE
Update atleast_1d syntax for new numpy versions

### DIFF
--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -423,7 +423,7 @@ def normalize_uv(u, v, wle):
     logging.info('  Normalizing u and v coordinates by provided'
                  ' observing wavelength of {} m'.format(wle))
 
-    wle = np.atleast_1d(wle, dtype='f8')
+    wle = np.atleast_1d(wle).astype('f8')
     if  len(wle) != 1 and len(wle) != len(u):
         raise ValueError("len(wle) = {}. It should be equal to "
                          "len(u) = {} (or 1 if all wavelengths are the same)".format(len(wle), len(u)))


### PR DESCRIPTION
`atleast_1d` call signature has changed in recent numpy versions (confirmed on v1.21.5; current version is 1.26.1). PR updates call signature to not rasie error in `utilities.normalize_uv`

Fixes #210 