### PR TITLE
solve_non_negative bug; increment frank version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout code

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 Changelog
 +++++++++
 
+v.1.2.3
++++++++
+*Two bug fixes, additional tests*
+- test.py
+    - Adds tests for `utilities` objects and for `radial_fitters.FrankFitter.log_evidence_laplace`
+- utilities.py 
+    - Adds option in `make_mock_data` to reproject
+    - Fixes bug in `normalize_uv`
+    - Fixes two bugs in `sweep_profile`
+- Docs:
+    - Minor updates to tutorials using `utilities.make_mock_data`
+
 v.1.2.2
 +++++++
 *One bug fix, some code refactoring, a couple new functionalities, integrates scale-height fits into command-line UI*

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,6 @@
 Installation
 ============
-``frank`` requires Python 3 and is tested for Python 3.7. Usage under Python 2.x is not supported.
+``frank`` requires Python 3 and is tested for versions listed in `setup.cfg`. Usage under Python 2.x is not supported.
 
 With pip
 --------

--- a/frank/__init__.py
+++ b/frank/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>
 #
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 from frank import constants
 from frank import geometry
@@ -25,6 +25,7 @@ from frank import io
 from frank import radial_fitters
 from frank import debris_fitters
 from frank import utilities
+
 
 def enable_logging(log_file=None):
     """Turn on internal logging for Frankenstein
@@ -38,13 +39,8 @@ def enable_logging(log_file=None):
     import logging
 
     if log_file is not None:
-        handlers = [ logging.FileHandler(log_file, mode='w'),
-                     logging.StreamHandler()
-                     ]
+        handlers = [logging.FileHandler(log_file, mode="w"), logging.StreamHandler()]
     else:
-        handlers = [ logging.StreamHandler() ]
+        handlers = [logging.StreamHandler()]
 
-    logging.basicConfig(level=logging.INFO,
-                        format='%(message)s',
-                        handlers=handlers
-                        )
+    logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=handlers)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,11 @@ classifiers =
     Intended Audience :: Science/Research
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 keywords =
     science
     astronomy
@@ -34,7 +34,7 @@ keywords =
 [options]
 packages = frank
 # python_requires docs: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-python_requires = >=3.7
+python_requires = >=3.8
 # PEP 440 - pinning package versions: https://www.python.org/dev/peps/pep-0440/#compatible-release
 install_requires =
     numpy>=1.12


### PR DESCRIPTION
This PR was at first meant to step frank from v1.2.2 to 1.2.3 after someone was trying to use the pip version of frank and encountered a bug that we fixed after that release. I figured I'd also bump the python versions to drop support for 3.7 and add support for 3.12.

However, a separate problem arose - the current [test](https://github.com/discsim/frank/blob/9de2461579c95ab3b6c484be4819f4681a735967/frank/tests.py#L317) for [`solve_non_negative`](https://github.com/discsim/frank/blob/9de2461579c95ab3b6c484be4819f4681a735967/frank/statistical_models.py#L838) passes on python 3.8 but not 3.9+, returning an array of `0`.  The underlying scipy [implementation](https://github.com/scipy/scipy/blob/v1.14.0/scipy/optimize/_nnls.py#L8-L95) was updated ~6 months ago. @rbooth200, do you have an idea for a quick fix? 