### PR TITLE
Add sanity check of (u,v) units

### DIFF
--- a/frank/fit.py
+++ b/frank/fit.py
@@ -818,6 +818,10 @@ def main(*args):
         u, v, vis, weights = alter_data(
             u, v, vis, weights, geom, model)
 
+    # check units of (u,v)
+    # (after conversion if model['modify_data']['norm_wle'] is True)
+    utilities.check_uv(u, v)
+
     if model['analysis']['bootstrap_ntrials']:
         boot_fig, boot_axes = perform_bootstrap(
             u, v, vis, weights, geom, model)

--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -401,6 +401,34 @@ class UVDataBinner(object):
         return [self._uv_left, self._uv_right]
 
 
+def check_uv(u, v, min_q=1e3, max_q=1e8):
+    """
+    Check if u,v distances are sensible for expected code unit of
+    [lambda], or if instead they're being supplied in [m].
+
+    Parameters
+    ----------
+    u, v : array, unit = :math:`\lambda`
+        u and v coordinates of observations
+    min_q : float, unit = :math:`\lambda`, default=1e3
+        Minimum baseline in code units expected for a dataset. The default
+        value of 1e3 is a conservative value for ALMA, assuming a minimum
+        antenna separation of ~12 m and maximum observing wavelength of 3.6 mm.
+    max_q : float, unit = :math:`\lambda`, default=1e5
+        Maximum baseline in code units expected for a dataset. The default
+        value of 1e8 is a conservative value for ALMA, assuming a maximum
+        antenna separation of ~16 km and minimum observing wavelength of 0.3 mm.
+    """
+    q = np.hypot(u, v)
+
+    if min(q) < min_q:
+        logging.warning("WARNING: "
+            f"Minimum baseline {min(q):.1e} < expected minimum {min_q:.1e} [lambda]. "
+            "'u' and 'v' distances must be in units of [lambda], " 
+            "but it looks like they're in [m]."
+        )
+
+
 def normalize_uv(u, v, wle):
     r"""
     Normalize data u and v coordinates by the observing wavelength

--- a/frank/utilities.py
+++ b/frank/utilities.py
@@ -402,7 +402,7 @@ class UVDataBinner(object):
 
 
 def check_uv(u, v, min_q=1e3, max_q=1e8):
-    """
+    r"""
     Check if u,v distances are sensible for expected code unit of
     [lambda], or if instead they're being supplied in [m].
 


### PR DESCRIPTION
People often pass in _u_ and _v_ coordinates in [m], then either the fit fails or they get confused by the fit results. This PR:
- adds a function to check the units and issue a warning if they appear to be in [m] rather than the expected [lambda]. 
- adds the check to the pipeline in `fit.py`