### PR TITLE
Fixed typo in geometry printing

### DIFF
--- a/frank/geometry.py
+++ b/frank/geometry.py
@@ -364,7 +364,7 @@ class SourceGeometry(object):
         return 1.0 / np.cos(self._inc * deg_to_rad)
         
     def __repr__(self):
-        return "SourceGeometry(inc={}, PA={}, dRA={}, dDEC={})".format(
+        return "SourceGeometry(inc={}, PA={}, dRA={}, dDec={})".format(
             self.inc, self.PA, self.dRA, self.dDec
         )
 


### PR DESCRIPTION
I spotted a typo when doing `print(geometry)`. This PR makes it so that the output can be simply copied to create a FixedGeometry object, which is useful, e.g., when fitting the geometry once.